### PR TITLE
Perl Shebang

### DIFF
--- a/xliff/decode_markup.pm
+++ b/xliff/decode_markup.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 package decode_markup;
 run() unless caller();
 

--- a/xliff/fix_markup_ws.pm
+++ b/xliff/fix_markup_ws.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 package fix_markup_ws;
 run() unless caller();
 

--- a/xliff/m4loc.pl
+++ b/xliff/m4loc.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 $|++;
 
 

--- a/xliff/m4loc.pm
+++ b/xliff/m4loc.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 package m4loc;
 

--- a/xliff/pseudo_translate.pm
+++ b/xliff/pseudo_translate.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 package pseudo_translate;
 
 run() unless caller();

--- a/xliff/recase_postprocess.pm
+++ b/xliff/recase_postprocess.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 package recase_postprocess;
 
 run() unless caller();

--- a/xliff/recase_preprocess.pm
+++ b/xliff/recase_preprocess.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 package recase_preprocess;
 
 run() unless caller();

--- a/xliff/reinsert.pm
+++ b/xliff/reinsert.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 package reinsert;
 run() unless caller();
 

--- a/xliff/reinsert_greedy.pm
+++ b/xliff/reinsert_greedy.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 package reinsert_greedy;
 run() unless caller();
 

--- a/xliff/reinsert_wordalign.pm
+++ b/xliff/reinsert_wordalign.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 package reinsert_wordalign;
 run() unless caller();
 

--- a/xliff/remove_markup.pm
+++ b/xliff/remove_markup.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 package remove_markup;
 run() unless caller();
 

--- a/xliff/wrap_detokenizer.pm
+++ b/xliff/wrap_detokenizer.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 package wrap_detokenizer;
 

--- a/xliff/wrap_markup.pm
+++ b/xliff/wrap_markup.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 package wrap_markup;
 run() unless caller();
 

--- a/xliff/wrap_tokenizer.pm
+++ b/xliff/wrap_tokenizer.pm
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 package wrap_tokenizer;
 


### PR DESCRIPTION
The "/usr/bin/perl" shebang changed to "/usr/bin/env perl" to allow using the perlbrew environment safely.

Implemented in xliff folder only.
